### PR TITLE
rubocop-loader: Add option to load config file from settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ gem install rubocop
 
 Specify configuration
 
-```
+```javascript
 {
 	//  or "ruby.rubocop.executePath": "/Users/you/.rbenv/shims/"
 	"ruby.rubocop.executePath": "D:/bin/Ruby22-x64/bin/",
+
+  // If not specified, it assumes a null value by default.
+  "ruby.rubocop.configFilePath": "/path/to/config/file",
 
 	// default true
 	"ruby.rubocop.onSave": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ruby-rubocop",
-	"version": "0.1.11",
+	"version": "0.1.12",
 	"publisher": "misogi",
 	"displayName": "ruby-rubocop",
 	"description": "execute rubocop for current Ruby code.",
@@ -53,6 +53,11 @@
 					"default": "",
 					"description": "execution path of rubocop."
 				},
+        "ruby.rubocop.configFilePath": {
+          "type": "string",
+          "default": null,
+          "description": "Filepath to the configuration file for Rubocop"
+        },
 				"ruby.rubocop.onSave": {
 					"type": "boolean",
 					"default": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "ES5",
+		"target": "es5",
 		"outDir": "out",
 		"noLib": true,
 		"sourceMap": true


### PR DESCRIPTION
This change adds the following options to the extension:
## Configuration

``` javascript
{
    //  or "ruby.rubocop.executePath": "/Users/you/.rbenv/shims/"
    "ruby.rubocop.executePath": "D:/bin/Ruby22-x64/bin/",
    // If not specified, assumes a null value by default.
    "ruby.rubocop.configFilePath": "/my/path/to/config/file.yml",
    // default true
    "ruby.rubocop.onSave": true
}
```
